### PR TITLE
Initial commit for theme update manager logic

### DIFF
--- a/includes/theme-update-manager.php
+++ b/includes/theme-update-manager.php
@@ -26,7 +26,7 @@ function pmproum_get_themes() {
 
 	// Query the server if we do not have the local $update_info or we force checking for an update.
 	if ( empty( $update_info ) || ! empty( $_REQUEST['force-check'] ) || current_time('timestamp') > $update_info_timestamp + 86400 ) {
-		/**
+        /**
          * Filter to change the timeout for this wp_remote_get() request for updates.
          * @since TBD
          * @param int $timeout The number of seconds before the request times out

--- a/includes/theme-update-manager.php
+++ b/includes/theme-update-manager.php
@@ -1,0 +1,121 @@
+<?php
+// This file is to add support for updating our themes in the event they are deactivated.
+
+/**
+ * Setup themes api filters
+ * @since TBD
+*/
+function pmproum_theme_setup_update_info() {
+
+	if ( ! defined( 'PMPRO_LICENSE_SERVER' ) ) {
+		define('PMPRO_LICENSE_SERVER', 'https://license.paidmembershipspro.com/v2/' );
+	}
+
+	add_filter( 'pre_set_site_transient_update_themes', 'pmproum_update_themes_filter' );
+}
+add_action( 'admin_init', 'pmproum_theme_setup_update_info', 99 );
+
+/**
+ * Get theme update information from the PMPro server.
+ * @since  TBD
+ */
+function pmproum_theme_get_update_info() {
+	// Check if forcing a pull from the server.
+	$update_info = get_option( 'pmproum_theme_update_info', false );
+	$update_info_timestamp = get_option( 'pmproum_theme_update_info_timestamp', 0 );
+
+	// Query the server if we do not have the local $update_info or we force checking for an update.
+	if ( empty( $update_info ) || ! empty( $_REQUEST['force-check'] ) || current_time('timestamp') > $update_info_timestamp + 86400 ) {
+		/**
+         * Filter to change the timeout for this wp_remote_get() request for updates.
+         * @since TBD
+         * @param int $timeout The number of seconds before the request times out
+         */
+        $timeout = apply_filters( 'pmproum_theme_get_update_info_timeout', 5 );
+        $remote_info = wp_remote_get( PMPRO_LICENSE_SERVER . 'themes/', $timeout );
+
+		// Test response.
+        if ( is_wp_error( $remote_info ) || empty( $remote_info['response'] ) || $remote_info['response']['code'] != '200' ) {
+			// Error.
+			return new WP_Error( 'connection_error', 'Could not connect to the PMPro License Server to get update information. Try again later.' );
+		} else {
+			// Update update_infos in cache.
+			$update_info = json_decode( wp_remote_retrieve_body( $remote_info ), true );
+			delete_option( 'pmproum_theme_update_info' );
+			add_option( 'pmproum_theme_update_info', $update_info, NULL, 'no' );
+		}
+
+		// Save timestamp of last update
+		delete_option( 'pmproum_theme_update_info_timestamp' );
+		add_option( 'pmproum_theme_update_info_timestamp', current_time('timestamp'), NULL, 'no' );
+	}
+
+	return $update_info;
+}
+
+/**
+* Infuse theme update details when WordPress runs its update checker.
+* @since TBD
+* @param object $value  The WordPress update object.
+* @return object $value Amended WordPress update object on success, default if object is empty.
+*/
+function pmproum_update_themes_filter( $value ) {
+
+	// If no update object exists, return early.
+	if ( empty( $value ) ) {
+		return $value;
+	}
+
+	// Get the update JSON for Stranger Studios themes
+	$update_info = pmproum_theme_get_update_info();
+
+	// No info found, let's bail.
+	if ( empty( $update_info ) ) {
+		return $value;
+	}
+
+    // Get our themes and figure out if we need to try and serve an update.
+	/**
+	 * Filter to add themes to the list of themes that should be updated. (Useful to let themes use update code without the need of bundling it in.)
+	 * @since TBD
+	 * @param array $themes An array of theme slugs that should be updated.
+	 */
+    $our_themes = apply_filters( 'pmproum_owned_themes', array( 'memberlite' ) );
+    
+	// Used to build an array of data to return to the transients
+    $theme_update_info = array();
+
+    // Loop through $our_themes to see if we need to serve an update.
+    foreach ( $our_themes as $theme_slug ) {
+
+		// Get data for the theme and make sure it is found in WordPress.
+        $theme_data = wp_get_theme( $theme_slug );
+
+		// If the theme is not found, skip it.
+        if ( is_wp_error( $theme_data ) ) {
+            continue;
+        }
+
+        // Find the theme update data in the update info array.
+        $find_theme = array_search( $theme_slug, array_column( $update_info, 'Slug' ) );
+
+        // If the theme update data is found, adjust $update_info to be specifically for memberlite.
+        if ( $find_theme !== false ) {
+            $theme_update_info = $update_info[$find_theme];
+        } else {
+            continue;
+        }   
+
+        // Compare versions and build the response array for each of our themes.
+        if ( ! empty( $theme_update_info['License'] ) && version_compare( $theme_data['Version'], $theme_update_info['Version'], '<' ) ){
+            $value->response[$theme_update_info['Slug']] = array(
+                'theme' => $theme_update_info['Slug'],
+                'new_version' => $theme_update_info['Version'],
+                'url' => $theme_update_info['ThemeURI'],
+                'package' => $theme_update_info['Download']
+            );
+        }
+    }
+
+    return $value;
+}

--- a/pmpro-update-manager.php
+++ b/pmpro-update-manager.php
@@ -16,6 +16,10 @@ define( 'PMPROUM_BASENAME', plugin_basename( __FILE__ ) );
 define( 'PMPROUM_DIR', dirname( __FILE__ ) );
 define( 'PMPROUM_VERSION', '0.1' );
 
+
+// Include the themes update manager.
+require_once( PMPROUM_DIR . '/includes/theme-update-manager.php' );
+
 /**
  * Some of the code in this library was borrowed from the TGM Updater class by Thomas Griffin. (https://github.com/thomasgriffin/TGM-Updater)
  */


### PR DESCRIPTION
* ENHANCEMENT: Adds support to let themes update within the Update Manager Add On.

Themes should still bundle this code natively or require the Update Manager Plugin. The idea is that themes should check their "own" update logic and not multiple themes. 

If a theme bundles update logic code inside their theme, it would be best to check if the Update Manager is installed or not and let the Update Manager handle the updates (to avoid duplicate calls to the JSON license server).

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-update-manager/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-update-manager/pulls/) for the same update/change?