### PR TITLE
Fix issue with GlotPress Helper

### DIFF
--- a/includes/glotpress-helper.php
+++ b/includes/glotpress-helper.php
@@ -21,7 +21,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-namespace PMProUM\Required\Traduttore_Registry;
+namespace PMPro\Required\Traduttore_Registry;
 
 use DateTime;
 

--- a/pmpro-update-manager.php
+++ b/pmpro-update-manager.php
@@ -225,7 +225,7 @@ function pmproum_check_for_translations() {
 		$product_slug = $product['Slug'];
 
 		// This uses the Traduttore plugin to check for translations for locales etc.
-		PMProUM\Required\Traduttore_Registry\add_project(
+		PMPro\Required\Traduttore_Registry\add_project(
 			$product_type,
 			$product_slug,
 			'https://translate.strangerstudios.com/api/translations/' . $product_slug


### PR DESCRIPTION
* BUG FIX: Fixes an issue when PMPro is active for translations. This will use the same class.

Some more testing needs to be done to ensure there are no race conditions while using the same classes. There shouldn't be but it's worth to test the following:

* Without PMPro core active.
* Activate PMPro core after activating the update manager.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-update-manager/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-update-manager/pulls/) for the same update/change?