### PR TITLE
Fix a race condition for GlotPress helper logic

### DIFF
--- a/includes/glotpress-helper.php
+++ b/includes/glotpress-helper.php
@@ -21,7 +21,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-namespace PMPro\Required\Traduttore_Registry;
+namespace PMProUM\Required\Traduttore_Registry;
 
 use DateTime;
 

--- a/includes/glotpress-helper.php
+++ b/includes/glotpress-helper.php
@@ -21,7 +21,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-namespace PMProUM\Required\Traduttore_Registry;
+namespace PMPro\Required\Traduttore_Registry;
 
 use DateTime;
 

--- a/pmpro-update-manager.php
+++ b/pmpro-update-manager.php
@@ -225,7 +225,7 @@ function pmproum_check_for_translations() {
 		$product_slug = $product['Slug'];
 
 		// This uses the Traduttore plugin to check for translations for locales etc.
-		PMProUM\Required\Traduttore_Registry\add_project(
+		PMPro\Required\Traduttore_Registry\add_project(
 			$product_type,
 			$product_slug,
 			'https://translate.strangerstudios.com/api/translations/' . $product_slug

--- a/pmpro-update-manager.php
+++ b/pmpro-update-manager.php
@@ -233,4 +233,4 @@ function pmproum_check_for_translations() {
 	}
 
 }
-add_action( 'admin_init', 'pmproum_check_for_translations', 99 ); // PMPro core runs this on priority 10.
+add_action( 'admin_init', 'pmproum_check_for_translations', 5 ); // PMPro core runs this on priority 10.

--- a/pmpro-update-manager.php
+++ b/pmpro-update-manager.php
@@ -16,18 +16,14 @@ define( 'PMPROUM_BASENAME', plugin_basename( __FILE__ ) );
 define( 'PMPROUM_DIR', dirname( __FILE__ ) );
 define( 'PMPROUM_VERSION', '0.1' );
 
-
-// Include the themes update manager.
+// Includes
 require_once( PMPROUM_DIR . '/includes/theme-update-manager.php' );
+require_once( PMPROUM_DIR . '/includes/glotpress-helper.php' );
 
 /**
  * Some of the code in this library was borrowed from the TGM Updater class by Thomas Griffin. (https://github.com/thomasgriffin/TGM-Updater)
  */
 
-// Only include the GlotPress helper if it's not already included by PMPro core.
-if ( ! function_exists( 'PMPro\Required\Traduttore_Registry\add_project' ) ) {
-	include( PMPROUM_DIR . '/includes/glotpress-helper.php' );
-}
 
 /**
  * Setup plugins api filters
@@ -225,7 +221,7 @@ function pmproum_check_for_translations() {
 		$product_slug = $product['Slug'];
 
 		// This uses the Traduttore plugin to check for translations for locales etc.
-		PMPro\Required\Traduttore_Registry\add_project(
+		PMProUM\Required\Traduttore_Registry\add_project(
 			$product_type,
 			$product_slug,
 			'https://translate.strangerstudios.com/api/translations/' . $product_slug


### PR DESCRIPTION
* BUG FIX: Fixes an issue where there was a typo in the namespace of the GlotPress helper file. This loads it via a custom name space and avoids a race condition with PMPro core when using the same namespace. We give Update Manager priority here for translations when activated.

A good way to test this is to:

1. Install the `pmpro-affiliates` Add On.
2. Set your locale to Italian (we have 100% translation and a package is available - we know this Add On is served from GlotPress as we don't have this hosted anywhere else for translations).
3. Pull this PR into local environment.
4. Clear all `_transients` from the `options` table.
5. See that translations are available for the Affiliates Add On.

Run steps 4-5 repeatedly with PMPro core active, deactivated and try to activate PMPro core _after_ Update Manager is already installed. No fatal errors should happen on core activation.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-update-manager/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-update-manager/pulls/) for the same update/change?