### PR TITLE
Fix error where memberlite was showing an update

### DIFF
--- a/includes/theme-update-manager.php
+++ b/includes/theme-update-manager.php
@@ -80,7 +80,7 @@ function pmproum_update_themes_filter( $value ) {
 
 			$theme_exists = wp_get_theme( $theme_info['Slug'] );
 
-			// Make sure the theme exists and that an update is available.
+			// Make sure the theme exists before we try to see if an update is needed.
 			if ( $theme_exists->exists() ) {
 				// Compare versions and build the response array for each of our themes.
 				if ( version_compare( $theme_exists['Version'], $theme_info['Version'], '<' ) ) {

--- a/includes/theme-update-manager.php
+++ b/includes/theme-update-manager.php
@@ -3,7 +3,7 @@
 
 /**
  * Setup themes api filters
- * @since TBD
+ * @since 0.2
 */
 function pmproum_theme_setup_update_info() {
 
@@ -17,7 +17,7 @@ add_action( 'admin_init', 'pmproum_theme_setup_update_info', 99 );
 
 /**
  * Get theme update information from the PMPro server.
- * @since  TBD
+ * @since  0.2
  */
 function pmproum_get_themes() {
 	// Check if forcing a pull from the server.
@@ -28,7 +28,7 @@ function pmproum_get_themes() {
 	if ( empty( $update_info ) || ! empty( $_REQUEST['force-check'] ) || current_time('timestamp') > $update_info_timestamp + 86400 ) {
         /**
          * Filter to change the timeout for this wp_remote_get() request for updates.
-         * @since TBD
+         * @since 0.2
          * @param int $timeout The number of seconds before the request times out
          */
         $timeout = apply_filters( 'pmproum_get_themes_timeout', 5 );
@@ -55,7 +55,7 @@ function pmproum_get_themes() {
 
 /**
 * Infuse theme update details when WordPress runs its update checker.
-* @since TBD
+* @since 0.2
 * @param object $value  The WordPress update object.
 * @return object $value Amended WordPress update object on success, default if object is empty.
 */
@@ -80,7 +80,8 @@ function pmproum_update_themes_filter( $value ) {
 
 			$theme_exists = wp_get_theme( $theme_info['Slug'] );
 
-			if ( ! is_wp_error( $theme_exists ) ) {
+			// Make sure the theme exists and that an update is available.
+			if ( $theme_exists->exists() ) {
 				// Compare versions and build the response array for each of our themes.
 				if ( version_compare( $theme_exists['Version'], $theme_info['Version'], '<' ) ) {
 					$value->response[$theme_info['Slug']] = array(


### PR DESCRIPTION
* BUG FIX: Fixed an issue where updates would show for memberlite when the theme wasn't installed.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-update-manager/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-update-manager/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves https://github.com/strangerstudios/pmpro-update-manager/issues/9

### How to test the changes in this Pull Request:

1. Check for updates before applying this patch, memberlite should show that an update is needed.
2. Apply the patch, clear transients and the update should disappear.
3. Copy over memberlite to wp-content/themes and change the version in styles.css and see that the update shows again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
