### PR TITLE
Add plugin row meta

### DIFF
--- a/pmpro-update-manager.php
+++ b/pmpro-update-manager.php
@@ -230,3 +230,18 @@ function pmproum_check_for_translations() {
 
 }
 add_action( 'admin_init', 'pmproum_check_for_translations', 5 ); // PMPro core runs this on priority 10.
+
+/**
+ * Function to add links to the plugin row meta
+ */
+function pmproum_plugin_row_meta( $links, $file ) {
+	if ( strpos( $file, 'pmpro-update-manager.php' ) !== false ) {
+		$new_links = array(
+			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/add-ons/update-manager/' ) . '" title="' . esc_attr( __( 'View Documentation', 'pmpro-update-manager' ) ) . '">' . __( 'Docs', 'pmpro-update-manager' ) . '</a>',
+			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/support/' ) . '" title="' . esc_attr( __( 'Visit Customer Support Forum', 'pmpro-update-manager' ) ) . '">' . __( 'Support', 'pmpro-update-manager' ) . '</a>',
+		);
+		$links     = array_merge( $links, $new_links );
+	}
+	return $links;
+}
+add_filter( 'plugin_row_meta', 'pmproum_plugin_row_meta', 10, 2 );


### PR DESCRIPTION
Add function `pmproum_plugin_row_meta` to add doc and support links to plugin row meta.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-update-manager/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-update-manager/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds functionality to show plugin documentation and support links.

### How to test the changes in this Pull Request:

1. Navigate to **Plugins > Installed Plugins**
2. Locate the "Paid Memberships Pro - Update Manager" plugin
3. Verify that the "Docs" and "Support" show and links correctly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> ENHANCEMENT: Add docs and support links to plugin row meta.
