### PR TITLE
Fix deprecation warning

### DIFF
--- a/classes/class-pmproum-addons.php
+++ b/classes/class-pmproum-addons.php
@@ -726,7 +726,7 @@ class PMProUM_AddOns {
 	 */
 	private function get_upgrader_skin() {
 		// Use the core automatic skin to avoid direct output.
-		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader-skins.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 		$args = array(
 			'skip_header' => true,
 			'url'         => admin_url( 'plugins.php' ),


### PR DESCRIPTION
Fixes a warning about a deprecated function when installing an Add On from the Membership > Add Ons screen.

See core PR here: https://github.com/strangerstudios/paid-memberships-pro/pull/3525