### PR TITLE
Bugfix: auto update runs in cron context, so the hook never fires, PMPro and Add Ons can't auto update

### DIFF
--- a/classes/class-pmproum-addons.php
+++ b/classes/class-pmproum-addons.php
@@ -353,6 +353,12 @@ class PMProUM_AddOns {
 			return $value;
 		}
 
+		// Ensure the get_plugin_data() function is available. This filter runs in all contexts,
+		// including WP-Cron and the front end, where wp-admin/includes/plugin.php is not always loaded.
+		if ( ! function_exists( 'get_plugin_data' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		// Check Add Ons
 		foreach ( $addons as $addon ) {
 			// Skip for wordpress.org plugins

--- a/classes/class-pmproum-addons.php
+++ b/classes/class-pmproum-addons.php
@@ -382,7 +382,8 @@ class PMProUM_AddOns {
 					$value->response[ $plugin_file ]->icons = array( 'default' => esc_url( $icon ) );
 				}
 			} else {
-				$value->no_update[ $plugin_file ] = $this->get_plugin_API_object_from_addon( $addon );
+				$value->no_update[ $plugin_file ]              = $this->get_plugin_API_object_from_addon( $addon );
+				$value->no_update[ $plugin_file ]->new_version = $addon['Version'];
 			}
 		}
 

--- a/classes/class-pmproum-addons.php
+++ b/classes/class-pmproum-addons.php
@@ -47,7 +47,28 @@ class PMProUM_AddOns {
 		$this->addons           = get_option( 'pmpro_addons', array() );
 		$this->addons_timestamp = get_option( 'pmpro_addons_timestamp', false );
 
+		// Register update hooks in all contexts, including WP-Cron, so PMPro plugins can auto-update in the background.
+		$this->update_hooks();
+
 		add_action( 'admin_init', array( $this, 'admin_hooks' ), 0 ); // Priority 0 to run before other admin_init hooks.
+	}
+
+	/**
+	 * Hooks that must run in all contexts, including WP-Cron.
+	 *
+	 * The plugin update injection and Add On download filters previously only
+	 * registered on admin_init. WordPress runs background auto-updates under
+	 * WP-Cron, where admin_init never fires, so these filters were absent and
+	 * PMPro core and Add Ons never auto-updated even with auto-updates enabled
+	 * and a valid license. Registering them unconditionally lets the automatic
+	 * updater see and install PMPro plugin updates.
+	 *
+	 * @since TBD
+	 */
+	public function update_hooks() {
+		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'update_plugins_filter' ) );
+		add_filter( 'http_request_args', array( $this, 'http_request_args_for_addons' ), 10, 2 );
+		add_action( 'update_option_pmpro_license_key', array( $this, 'reset_update_plugins_cache' ), 10, 2 );
 	}
 
 	/**
@@ -94,9 +115,6 @@ class PMProUM_AddOns {
 	public function admin_hooks() {
 		$this->check_when_updating_plugins();
 		add_filter( 'plugins_api', array( $this, 'plugins_api' ), 10, 3 );
-		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'update_plugins_filter' ) );
-		add_filter( 'http_request_args', array( $this, 'http_request_args_for_addons' ), 10, 2 );
-		add_action( 'update_option_pmpro_license_key', array( $this, 'reset_update_plugins_cache' ), 10, 2 );
 		// Register AJAX endpoints for add-on actions.
 		$this->register_ajax_endpoints();
 	}

--- a/includes/license.php
+++ b/includes/license.php
@@ -62,3 +62,18 @@ if ( ! function_exists( 'pmpro_license_isValid' ) ) {
         return false;
     }
 }
+
+if ( ! function_exists( 'pmpro_setMessage' ) ) {
+    /**
+     * Queue a message for display in the admin.
+     * This is a no-op here. If PMPro were active, the function
+     * there would be used instead and really set the message.
+     * PMProUM_AddOns::get_remote_addons() calls this when the
+     * License Server cannot be reached, and that code now runs in
+     * all contexts, including WP-Cron, where calling an undefined
+     * function would be fatal. Nothing in this Add On displays
+     * these messages, so there is nothing to store.
+     */
+    function pmpro_setMessage( $message, $type, $force = false ) {
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -27,6 +27,9 @@ Manage downloads and updates for all official Paid Memberships Pro Add Ons, them
 View full documentation at: https://www.paidmembershipspro.com/add-ons/update-manager/
 
 == Changelog ==
+= TBD =
+* BUG FIX: Fixed PMPro core and Add Ons never auto-updating in the background because the update hooks only registered on `admin_init`, which does not fire during WP-Cron where automatic updates run. (@dalemugford)
+
 = 1.0.1 - 2025-11-12 =
 * BUG FIX: Fixed a deprecation warning when installing Add Ons from the Membership > Add Ons screen. #16 (@dparker1005)
 

--- a/readme.txt
+++ b/readme.txt
@@ -29,6 +29,7 @@ View full documentation at: https://www.paidmembershipspro.com/add-ons/update-ma
 == Changelog ==
 = TBD =
 * BUG FIX: Fixed PMPro core and Add Ons never auto-updating in the background because the update hooks only registered on `admin_init`, which does not fire during WP-Cron where automatic updates run. (@dalemugford)
+* BUG FIX: Set `new_version` on `no_update` entries so up-to-date Add Ons no longer trigger an undefined-property warning in WP-CLI and other consumers of the update transient. (@dalemugford)
 
 = 1.0.1 - 2025-11-12 =
 * BUG FIX: Fixed a deprecation warning when installing Add Ons from the Membership > Add Ons screen. #16 (@dparker1005)


### PR DESCRIPTION
## Problem

PMPro core and Add Ons never auto-update in the background, even with WordPress auto-updates enabled and a valid license. Reproduced on a live site stuck on PMPro 3.8.1 while 3.8.2 was available; other (wp.org) plugins on the same site auto-updated fine.

## Root cause

Since PMPro left the wp.org repository, plugin updates are injected into WordPress's `update_plugins` transient by this plugin's `pre_set_site_transient_update_plugins` filter. That filter (and the `http_request_args` download filter) is registered inside `admin_hooks()`, which is only hooked to `admin_init`:

```php
add_action( 'admin_init', array( $this, 'admin_hooks' ), 0 );
```

`admin_init` only fires on wp-admin requests. WordPress runs automatic background updates under **WP-Cron** (`wp_version_check` / `wp_update_plugins` / `wp_maybe_auto_update`), where `admin_init` never fires. So during the cron run the filter is not attached, the transient is rebuilt without any PMPro updates, and the automatic updater finds nothing to install. Manual updates work because loading wp-admin fires `admin_init`.

Confirmed on the affected site: during a real `wp_update_plugins()` run the callbacks on `pre_set_site_transient_update_plugins` were third-party plugins only; PMPro's was absent. Calling `update_plugins_filter()` directly injected `3.8.2` correctly, so the logic is right, it was just never wired up under cron. This affects core and every Add On distributed through Update Manager.

## Fix

Move the hooks that must run in all contexts into a new `update_hooks()` method called unconditionally from the constructor:

- `pre_set_site_transient_update_plugins` (inject available updates)
- `http_request_args` (disable SSL verify for license-server package downloads during upgrade)
- `update_option_pmpro_license_key` (clear caches when the key changes)

The admin-only pieces (`plugins_api` details modal, `check_when_updating_plugins()`, AJAX endpoints) stay on `admin_init`. `PMProUM_AddOns::instance()` is already created on `init`, which fires under cron, so the filters are in place before the transient is set.

## Testing

- `php -l` clean.
- Verified on the affected site that with the filter attached in a non-admin context, `wp_update_plugins()` populates `response[paid-memberships-pro/paid-memberships-pro.php]` with the newer version.