### PR TITLE
Guard pmpro_setMessage() calls instead of declaring a stub

### DIFF
--- a/classes/class-pmproum-addons.php
+++ b/classes/class-pmproum-addons.php
@@ -1151,7 +1151,10 @@ class PMProUM_AddOns {
 
 		// Check for errors and if we're okay, save the addons formatted
 		if ( is_wp_error( $remote_addons ) ) {
-			pmpro_setMessage( 'Could not connect to the PMPro License Server to update addon information. Try again later.', 'error' );
+			// pmpro_setMessage() is only available when PMPro core is active.
+			if ( function_exists( 'pmpro_setMessage' ) ) {
+				pmpro_setMessage( 'Could not connect to the PMPro License Server to update addon information. Try again later.', 'error' );
+			}
 			// Return cached addons if available
 			return $this->addons ? : array();
 		} elseif ( ! empty( $remote_addons ) && $remote_addons['response']['code'] == 200 ) {
@@ -1163,7 +1166,10 @@ class PMProUM_AddOns {
 
 			// If for some reason the addons are not formatted correctly
 			if ( empty( $addons ) ) {
-				pmpro_setMessage( 'No addons found.', 'error' );
+				// pmpro_setMessage() is only available when PMPro core is active.
+				if ( function_exists( 'pmpro_setMessage' ) ) {
+					pmpro_setMessage( 'No addons found.', 'error' );
+				}
 				return $addons;
 			}
 

--- a/includes/license.php
+++ b/includes/license.php
@@ -62,18 +62,3 @@ if ( ! function_exists( 'pmpro_license_isValid' ) ) {
         return false;
     }
 }
-
-if ( ! function_exists( 'pmpro_setMessage' ) ) {
-    /**
-     * Queue a message for display in the admin.
-     * This is a no-op here. If PMPro were active, the function
-     * there would be used instead and really set the message.
-     * PMProUM_AddOns::get_remote_addons() calls this when the
-     * License Server cannot be reached, and that code now runs in
-     * all contexts, including WP-Cron, where calling an undefined
-     * function would be fatal. Nothing in this Add On displays
-     * these messages, so there is nothing to store.
-     */
-    function pmpro_setMessage( $message, $type, $force = false ) {
-    }
-}


### PR DESCRIPTION
## Problem

With Update Manager 1.0.2 active, activating (or re-activating) PMPro core fatals:

> Cannot redeclare pmpro_setMessage() (previously declared in /wp-content/plugins/pmpro-update-manager/includes/license.php:77)

WordPress's activation sandbox catches the fatal, so core **cannot be activated at all** while Update Manager 1.0.2 is active.

### Root cause

On the activation request, core is not yet active, so at `init` the Update Manager loads its `includes/license.php` and declares the `pmpro_setMessage()` stub added in 1.0.2 (#18). Later in the same request, `activate_plugin()` includes core's `includes/functions.php`, which declares `pmpro_setMessage()` unguarded → fatal.

The three license function stubs are not affected: core only declares those inside its own `includes/license.php`, which core skips whenever `PMPRO_LICENSE_SERVER` is already defined.

## Fix

Remove the `pmpro_setMessage()` stub and instead wrap the two call sites in `PMProUM_AddOns` with `function_exists()` checks. This keeps the WP-Cron safety from #18 (no undefined-function fatal when core is absent) without ever declaring a function that core declares unguarded.

A matching PR applies the same call-site guards to core's `PMPro_AddOns` class so the two classes stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)